### PR TITLE
Fix: Repair desktop savefile writing

### DIFF
--- a/kanbansim/lib/common/input_output_file_picker/input/save_file_picker_desktop.dart
+++ b/kanbansim/lib/common/input_output_file_picker/input/save_file_picker_desktop.dart
@@ -5,12 +5,12 @@ import 'package:kanbansim/common/input_output_file_picker/input/filepicker_inter
 import 'dart:io';
 import 'package:kanbansim/common/input_output_file_picker/input_output_supplier.dart';
 
-class SaveFilePicker implements FilePicker {
+class SaveFilePickerDesktop implements FilePicker {
   final Function(String) returnPickedFilePath;
   FileTileSelectMode filePickerSelectMode = FileTileSelectMode.wholeTile;
   BuildContext context;
 
-  SaveFilePicker({
+  SaveFilePickerDesktop({
     @required this.returnPickedFilePath,
     @required this.context,
   });

--- a/kanbansim/lib/common/input_output_file_picker/output/save_file_writer_desktop.dart
+++ b/kanbansim/lib/common/input_output_file_picker/output/save_file_writer_desktop.dart
@@ -1,14 +1,8 @@
 import 'package:kanbansim/common/input_output_file_picker/input_output_supplier.dart';
-import 'package:kanbansim/common/input_output_file_picker/output/filewriter_interface.dart';
+import 'package:kanbansim/common/input_output_file_picker/output/save_file_writer_interface.dart';
 import 'dart:io';
 
-class SaveFileWriter implements FileWriter {
-  Directory saveFilesDirectory;
-
-  SaveFileWriter() {
-    this.saveFilesDirectory = InputOutputSupplier.getSaveFilesDirectory();
-  }
-
+class SaveFileWriterDesktop implements SaveFileWriterInterface {
   @override
   void saveFileAs(String filename, String content) async {
     File saveFile = File(
@@ -20,11 +14,12 @@ class SaveFileWriter implements FileWriter {
     _writeToFile(saveFile, content);
   }
 
-  @override
   bool isNameAlreadyTaken(String filename) {
-    File tempSaveFile = File(_getSaveFilenameCompletePath(
-      InputOutputSupplier.formatFilename(filename),
-    ));
+    File tempSaveFile = File(
+      _getSaveFilenameCompletePath(
+        InputOutputSupplier.formatFilename(filename),
+      ),
+    );
 
     return tempSaveFile.existsSync();
   }
@@ -34,7 +29,7 @@ class SaveFileWriter implements FileWriter {
   }
 
   String _getSaveFilenameCompletePath(String filename) {
-    return this.saveFilesDirectory.path +
+    return InputOutputSupplier.getSaveFilesDirectory().path +
         Platform.pathSeparator +
         filename +
         ".ksim";

--- a/kanbansim/lib/common/input_output_file_picker/output/save_file_writer_interface.dart
+++ b/kanbansim/lib/common/input_output_file_picker/output/save_file_writer_interface.dart
@@ -1,4 +1,4 @@
-abstract class FileWriter {
+abstract class SaveFileWriterInterface {
   void saveFileAs(String filename, String content);
   bool isNameAlreadyTaken(String filename);
 }

--- a/kanbansim/lib/common/input_output_file_picker/output/save_file_writer_web.dart
+++ b/kanbansim/lib/common/input_output_file_picker/output/save_file_writer_web.dart
@@ -1,14 +1,13 @@
 import 'dart:convert';
-
 import 'package:kanbansim/common/input_output_file_picker/input_output_supplier.dart';
-import 'package:kanbansim/common/input_output_file_picker/output/filewriter_interface.dart';
-import 'dart:html';
+import 'package:kanbansim/common/input_output_file_picker/output/save_file_writer_interface.dart';
+import 'package:universal_html/html.dart' as html;
 
-class SaveFileWriterWeb implements FileWriter {
+class SaveFileWriterWeb implements SaveFileWriterInterface {
   String _formattedFilename;
-  Blob _file;
+  html.Blob _file;
   String _url;
-  AnchorElement _anchor;
+  html.AnchorElement _anchor;
 
   @override
   void saveFileAs(String filename, String content) async {
@@ -25,8 +24,8 @@ class SaveFileWriterWeb implements FileWriter {
   }
 
   void _cleanUp() {
-    document.body.children.remove(this._anchor);
-    Url.revokeObjectUrl(this._url);
+    html.document.body.children.remove(this._anchor);
+    html.Url.revokeObjectUrl(this._url);
   }
 
   void _downloadFile() {
@@ -34,19 +33,19 @@ class SaveFileWriterWeb implements FileWriter {
   }
 
   void _prepareAnchor() {
-    this._url = Url.createObjectUrlFromBlob(this._file);
+    this._url = html.Url.createObjectUrlFromBlob(this._file);
 
-    this._anchor = document.createElement('a') as AnchorElement
+    this._anchor = html.document.createElement('a') as html.AnchorElement
       ..href = this._url
       ..style.display = 'none'
       ..download = this._formattedFilename;
 
-    document.body.children.add(_anchor);
+    html.document.body.children.add(_anchor);
   }
 
   void _prepareFile(String content) {
     final bytes = utf8.encode(content);
-    this._file = Blob([bytes]);
+    this._file = html.Blob([bytes]);
   }
 
   void _prepareFilename(String filename) {

--- a/kanbansim/lib/features/input_output_popups/load_file_popup.dart
+++ b/kanbansim/lib/features/input_output_popups/load_file_popup.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:file_picker_cross/file_picker_cross.dart';
 import 'package:kanbansim/common/input_output_file_picker/input/filepicker_interface.dart';
-import 'package:kanbansim/common/input_output_file_picker/input/save_file_picker.dart';
+import 'package:kanbansim/common/input_output_file_picker/input/save_file_picker_desktop.dart';
 import 'package:kanbansim/common/input_output_file_picker/input/save_file_picker_web.dart';
 import 'package:kanbansim/features/notifications/feedback_popup.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -59,7 +59,7 @@ class _LoadFilePageState extends State<_LoadFilePage> {
         },
       );
     } else {
-      this._picker = SaveFilePicker(
+      this._picker = SaveFilePickerDesktop(
         context: context,
         returnPickedFilePath: (String filePath) {
           setState(() {

--- a/kanbansim/lib/features/input_output_popups/save_file_popup.dart
+++ b/kanbansim/lib/features/input_output_popups/save_file_popup.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:kanbansim/common/input_output_file_picker/input_output_supplier.dart';
-import 'package:kanbansim/common/input_output_file_picker/output/save_file_writer.dart';
+import 'package:kanbansim/common/input_output_file_picker/output/save_file_writer_desktop.dart';
+import 'package:kanbansim/common/input_output_file_picker/output/save_file_writer_interface.dart';
 import 'package:kanbansim/common/input_output_file_picker/output/save_file_writer_web.dart';
-import 'package:kanbansim/common/input_output_file_picker/output/filewriter_interface.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:intl/intl.dart';
 import 'package:kanbansim/features/notifications/subtle_message.dart';
@@ -41,7 +41,7 @@ class _SaveFilePage extends StatefulWidget {
 
 class _SaveFilePageState extends State<_SaveFilePage> {
   TextEditingController _controller;
-  FileWriter creator;
+  SaveFileWriterInterface creator;
   String warningMessage = '';
   String fileName = '';
   double _cornerRadius = 35;
@@ -75,7 +75,7 @@ class _SaveFilePageState extends State<_SaveFilePage> {
     if (kIsWeb) {
       this.creator = SaveFileWriterWeb();
     } else {
-      this.creator = SaveFileWriter();
+      this.creator = SaveFileWriterDesktop();
     }
   }
 

--- a/kanbansim/pubspec.lock
+++ b/kanbansim/pubspec.lock
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   disk_space_ns:
     dependency: transitive
     description:
@@ -147,6 +154,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   http:
     dependency: transitive
     description:
@@ -348,6 +362,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  universal_html:
+    dependency: "direct main"
+    description:
+      name: universal_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   vector_math:
     dependency: transitive
     description:

--- a/kanbansim/pubspec.yaml
+++ b/kanbansim/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
     sdk: flutter
   intl: ^0.17.0
   expandable: ^5.0.1
+  universal_html: ^2.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- replaced dart:html librairy by universal dart html librairy (html doesn't work for desktops).
- renamed classes responsible for i/o handling.
- fixed null exception appearing when trying to save file on desktop.