### PR TITLE
Storymode mechanics improvements

### DIFF
--- a/kanbansim/lib/common/story_module.dart
+++ b/kanbansim/lib/common/story_module.dart
@@ -51,6 +51,8 @@ class StoryModule {
 
   void simulationHasBegun() {
     _showNoteFromManagement(0);
+    _pushNotificationForDay(0);
+    _restoreProductivitiesAfterNewDay();
   }
 
   void switchedToNextDay() {
@@ -145,24 +147,15 @@ class StoryModule {
   }
 
   void _restoreRandomProductivity(User user) {
-    int diceRoll = Random().nextInt(100) + 1;
+    int diceRoll = Random().nextInt(5) + 1;
 
-    if (_isInRange(diceRoll, 0, 10)) {
-      user.addProductivity(1);
-    } else if (_isInRange(diceRoll, 11, 30)) {
-      user.addProductivity(2);
-    } else if (_isInRange(diceRoll, 31, 65)) {
-      user.addProductivity(3);
-    } else if (_isInRange(diceRoll, 66, 90)) {
-      user.addProductivity(4);
-    } else if (_isInRange(diceRoll, 91, 100)) {
-      user.addProductivity(5);
-    }
+    user.addProductivity(diceRoll);
 
     this._eventOccured(
-        EventType.INFO,
-        "${AppLocalizations.of(context).teamMember} ${user.getName()} ${AppLocalizations.of(context).startedDayWithProductivityEqualTo} ${user.getProductivity()}.",
-        false);
+      EventType.INFO,
+      "${AppLocalizations.of(context).teamMember} ${user.getName()} ${AppLocalizations.of(context).startedDayWithProductivityEqualTo} ${user.getProductivity()}.",
+      false,
+    );
   }
 
   bool _isInRange(int number, int min, int max) {

--- a/kanbansim/lib/common/story_module.dart
+++ b/kanbansim/lib/common/story_module.dart
@@ -15,7 +15,7 @@ class StoryModule {
 
   final BuildContext context;
   final int _MAX_DAYS = 10;
-  final double _LOCK_PROBABILITY = 0.15;
+  final double _LOCK_PROBABILITY = 0.20;
   final List<int> _POSSIBLE_PRODUCTIVITIES_TO_UNLOCK = [2, 3, 4];
 
   List<String> _scriptedMessages;

--- a/kanbansim/lib/features/main_page/widgets/kanban_board/create_new_task/task_creator_popup/UserSelector.dart
+++ b/kanbansim/lib/features/main_page/widgets/kanban_board/create_new_task/task_creator_popup/UserSelector.dart
@@ -24,11 +24,20 @@ class UserSelector extends StatefulWidget {
 class UserSelectorState extends State<UserSelector> {
   String _selectedUser;
 
-  @override
-  Widget build(BuildContext context) {
+  void _setDefaultSelectedUserIfNeeded() {
     if (this._selectedUser == null) {
       _selectedUser = widget.initialUserName;
     }
+
+    if (this.widget.ownerName != null &&
+        this.widget.names.contains(this.widget.ownerName)) {
+      _selectedUser = this.widget.ownerName;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _setDefaultSelectedUserIfNeeded();
 
     return Container(
       width: this.widget.subWidth,

--- a/kanbansim/lib/features/main_page/widgets/kanban_board/task_card/task_card_window/lock_status_popup.dart
+++ b/kanbansim/lib/features/main_page/widgets/kanban_board/task_card/task_card_window/lock_status_popup.dart
@@ -126,7 +126,11 @@ class _LockStatusState extends State<_LockStatus> {
     List<String> names = _getAvailableUsersNames();
     if (names.length != 0) {
       if (_selectedValue == null) {
-        _selectedValue = names[0];
+        if (this.widget.task.owner != null) {
+          _selectedValue = this.widget.task.owner.getName();
+        } else {
+          _selectedValue = names[0];
+        }
       }
 
       this._readyToUnlock = true;

--- a/kanbansim/lib/features/main_page/widgets/story_logs/story_panel.dart
+++ b/kanbansim/lib/features/main_page/widgets/story_logs/story_panel.dart
@@ -148,25 +148,11 @@ class _Logs extends StatelessWidget {
 
   List<ListTile> _getTiles(BuildContext context) {
     List<ListTile> tiles = <ListTile>[];
-    tiles.add(
-      ListTile(
-        title: Container(
-          height: 1,
-          width: MediaQuery.of(context).size.height,
-          color: Theme.of(context).hintColor,
-        ),
-      ),
-    );
 
     int length = this.messages.length;
-    for (int i = length - 1; i >= 0; i--) {
-      tiles.add(
-        ListTile(
-          title: SelectableText(
-            this.messages[i],
-          ),
-        ),
-      );
+    if (length == 0) {
+      return tiles;
+    } else {
       tiles.add(
         ListTile(
           title: Container(
@@ -176,8 +162,27 @@ class _Logs extends StatelessWidget {
           ),
         ),
       );
-    }
 
-    return tiles;
+      for (int i = length - 1; i >= 0; i--) {
+        tiles.add(
+          ListTile(
+            title: SelectableText(
+              this.messages[i],
+            ),
+          ),
+        );
+        tiles.add(
+          ListTile(
+            title: Container(
+              height: 1,
+              width: MediaQuery.of(context).size.height,
+              color: Theme.of(context).hintColor,
+            ),
+          ),
+        );
+      }
+
+      return tiles;
+    }
   }
 }

--- a/kanbansim/lib/models/User.dart
+++ b/kanbansim/lib/models/User.dart
@@ -15,7 +15,7 @@ class User {
     this._color = color;
 
     this._id = _registeredUsersAmount++;
-    this._productivity = maxProductivity;
+    this._productivity = 0;
   }
 
   void loadAdditionalDataFromSavefile(int id, int productivity) {


### PR DESCRIPTION
Improved simulation's start:
- forced users to start first day with random productivities.
- made first greeting message to appear in simulation's logs.
- changed probabilities of restored productivity's amount.

Increased of task's blockade:
- changed chance of task's block from 15% to 20%.
 
Made owner as default selected value for user dropdown lists.


Fixed logs formatting:
- changed dividers use.